### PR TITLE
Refactor dependencies to reduce viewer app size

### DIFF
--- a/.github/workflows/build-macos-app.yml
+++ b/.github/workflows/build-macos-app.yml
@@ -25,10 +25,24 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install dependencies
+      - name: Install Viewer dependencies
         run: |
           python -m pip install --upgrade pip
           pip install .
+
+      - name: Run PyInstaller for Viewer
+        run: |
+          pyinstaller src/trailcam_classifier_app/viewer.py \
+            --name TrailcamViewer \
+            --windowed
+
+      - name: Package Viewer application
+        run: |
+          hdiutil create -volname "TrailcamViewer" -srcfolder "dist/TrailcamViewer.app" -ov -format UDZO "TrailcamViewer.dmg"
+
+      - name: Install GUI dependencies
+        run: |
+          pip install .[gui]
 
       - name: Run PyInstaller for GUI
         run: |
@@ -40,16 +54,6 @@ jobs:
       - name: Package GUI application
         run: |
           hdiutil create -volname "TrailcamClassifier" -srcfolder "dist/TrailcamClassifier.app" -ov -format UDZO "TrailcamClassifier.dmg"
-
-      - name: Run PyInstaller for Viewer
-        run: |
-          pyinstaller src/trailcam_classifier_app/viewer.py \
-            --name TrailcamViewer \
-            --windowed
-
-      - name: Package Viewer application
-        run: |
-          hdiutil create -volname "TrailcamViewer" -srcfolder "dist/TrailcamViewer.app" -ov -format UDZO "TrailcamViewer.dmg"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,13 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-    "trailcam-classifier @ git+https://github.com/abaire/trailcam-classifier.git",
     "PySide6",
     "pyinstaller",
+]
+
+[project.optional-dependencies]
+gui = [
+    "trailcam-classifier @ git+https://github.com/abaire/trailcam-classifier.git",
 ]
 
 [project.scripts]

--- a/src/trailcam_classifier_app/util.py
+++ b/src/trailcam_classifier_app/util.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import itertools
+import os
+from pathlib import Path
+
+DEFAULT_IMAGE_EXTENSIONS = {"jpg", "jpeg"}
+
+
+def find_images(
+    input_dirs: list[str], ignore_dirs: list[str] | None = None, extensions: set[str] | None = None
+) -> set[Path]:
+    """Recursively finds all images in the given input_dirs."""
+
+    if not extensions:
+        extensions = DEFAULT_IMAGE_EXTENSIONS
+
+    input_dirs = [Path(os.path.expanduser(input_dir)) for input_dir in input_dirs]
+
+    combined_results = itertools.chain.from_iterable(base_path.rglob("*.*") for base_path in input_dirs)
+    all_files = set(combined_results)
+
+    if ignore_dirs is None:
+        ignore_dirs = []
+    ignored_paths = [Path(ignored) for ignored in ignore_dirs]
+
+    def keep_file(filename: Path) -> bool:
+        if any(filename.is_relative_to(ignored) for ignored in ignored_paths):
+            return False
+
+        if not filename.is_file():
+            return False
+
+        return filename.suffix[1:].lower() in extensions
+
+    return {filename for filename in all_files if keep_file(filename)}

--- a/src/trailcam_classifier_app/viewer.py
+++ b/src/trailcam_classifier_app/viewer.py
@@ -16,7 +16,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from trailcam_classifier.util import find_images
+from trailcam_classifier_app.util import find_images
 
 
 class AnnotationLabel(QLabel):


### PR DESCRIPTION
The TrailcamViewer application was unnecessarily large because it was being bundled with the `trailcam-classifier` dependency and its large sub-dependencies (ultralytics, torch).

This was because both the viewer and the classifier GUI shared the same dependency installation step in the build process.

This change introduces an optional `[gui]` dependency group for the classifier-specific dependencies. The build workflow is updated to install only the base dependencies when building the viewer, and then install the `[gui]` dependencies when building the classifier GUI.

To completely remove the `trailcam-classifier` dependency from the viewer, the `find_images` utility function was copied into the local application.