### PR TITLE
Fix: Use unique tag for release action and name

### DIFF
--- a/.github/workflows/build-macos-app.yml
+++ b/.github/workflows/build-macos-app.yml
@@ -71,6 +71,8 @@ jobs:
     needs: [ Build ]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
 
       - uses: actions/download-artifact@v4
@@ -83,35 +85,18 @@ jobs:
           name: Viewer
           path: .
 
-      - name: Create or update release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate tag
+        id: tag
+        run: echo "TAG_NAME=release-$(date +'%Y-%m-%d-%H-%M-%S')" >> $GITHUB_ENV
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: latest
-          release_name: Latest Build
+          tag_name: ${{ env.TAG_NAME }}
+          name: ${{ env.TAG_NAME }}
           body: |
             Automated build of the latest version of the Trailcam Classifier GUI.
-          draft: false
-          prerelease: false
-
-      - name: Upload GUI Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./TrailcamClassifier.dmg
-          asset_name: TrailcamClassifier.dmg
-          asset_content_type: application/octet-stream
-
-      - name: Upload Viewer Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./TrailcamViewer.dmg
-          asset_name: TrailcamViewer.dmg
-          asset_content_type: application/octet-stream
+          make_latest: true
+          files: |
+            TrailcamClassifier.dmg
+            TrailcamViewer.dmg


### PR DESCRIPTION
The create release action was failing because it was using a static tag name 'latest'. This change fixes the issue by generating a unique tag name based on the current timestamp for each release.

- Replaced the archived `actions/create-release@v1` with `softprops/action-gh-release@v2`.
- Added a step to generate a unique timestamp-based tag.
- Configured the new action to mark the release as "latest" and upload the build artifacts.
- The release name is now the same as the tag name.
- Added the required `permissions` to the workflow job.