### PR TITLE
refactor: Update confidence default and remove comments

### DIFF
--- a/.github/workflows/build-macos-app.yml
+++ b/.github/workflows/build-macos-app.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Run PyInstaller for Viewer
         run: |
+          # Required to convert the icon PNG.
+          pip install pillow
           pyinstaller src/trailcam_classifier_app/viewer.py \
             --name TrailcamViewer \
             --windowed \


### PR DESCRIPTION
Updates the default confidence threshold to 65 as requested. Removes obvious comments from the settings dialog.